### PR TITLE
Fix .travis.yml to install requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ deploy:
     tags: true
 
 install:
+  - pip install -r requirements.txt
   - pip install circuitpython-build-tools Sphinx sphinx-rtd-theme
   - pip install --force-reinstall pylint==1.9.2
 


### PR DESCRIPTION
.travis.yml was missing this line, which breaks pypi (we had the same problem with a previous library).