### PR TITLE
Update README Travis Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Introduction
     :target: https://discord.gg/nBQh6qu
     :alt: Discord
 
-.. image:: https://travis-ci.org/adafruit/Adafruit_CircuitPython_NeoTrellis.svg?branch=master
-    :target: https://travis-ci.org/adafruit/Adafruit_CircuitPython_NeoTrellis
+.. image:: https://travis-ci.com/adafruit/Adafruit_CircuitPython_NeoTrellis.svg?branch=master
+    :target: https://travis-ci.com/adafruit/Adafruit_CircuitPython_NeoTrellis
     :alt: Build Status
 
 This is a library for using the Adafruit_NeoTrellis boards with circuitpython.


### PR DESCRIPTION
Change 'travis-ci.org' to 'travis-ci.com'.