### PR TITLE
Add setuptools-scm to build system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@
 requires = [
     "setuptools",
     "wheel",
+    "setuptools-scm",
 ]
 
 [project]


### PR DESCRIPTION
Adabot patch changes for adding `setuptools-scm` as a build system requirement in `pyproject.toml`.