### PR TITLE
Improve performance with (optional, disabled by default) manual sync

### DIFF
--- a/adafruit_neotrellis/multitrellis.py
+++ b/adafruit_neotrellis/multitrellis.py
@@ -100,6 +100,12 @@ class MultiTrellis:
                             x = int(evt.number % 4) + _m * 4
                             _t.callbacks[evt.number](x, y, evt.edge)
 
+    def show(self):
+        """Show the colors on the NeoPixels"""
+        for _n in range(self._rows):
+            for _m in range(self._cols):
+                self._trelli[_n][_m].show()
+
     @property
     def brightness(self):
         """The NeoPixel brightness level of all clustered NeoTrellis boards."""

--- a/adafruit_neotrellis/neotrellis.py
+++ b/adafruit_neotrellis/neotrellis.py
@@ -66,6 +66,7 @@ class NeoTrellis(Keypad):
         addr=_NEO_TRELLIS_ADDR,
         drdy=None,
         brightness=1.0,
+        auto_write=True,
     ):
         super().__init__(i2c_bus, addr, drdy)
         self.interrupt_enabled = interrupt
@@ -77,6 +78,7 @@ class NeoTrellis(Keypad):
             _NEO_TRELLIS_NUM_KEYS,
             brightness=self._brightness,
             pixel_order=GRB,
+            auto_write=auto_write,
         )
 
     def activate_key(self, key, edge, enable=True):
@@ -102,6 +104,10 @@ class NeoTrellis(Keypad):
                     and self.callbacks[evt.number] is not None
                 ):
                     self.callbacks[evt.number](evt)
+
+    def show(self):
+        """Show the NeoPixels on the Trellis"""
+        self.pixels.show()
 
     @property
     def brightness(self):


### PR DESCRIPTION
Digging through the Arduino side of things, I found there's a manual sync step after any pixel change, whereas the CircuitPython libraries will by default auto-sync any time a pixel is changed. This is ideal from a user standpoint, but if you update more than one pixel at a time it slows down significantly, as there's an I2C transmit every time you update a single neopixel. For anyone who wants to update multiple pixels at a time, I've added a way to do a single manual sync after a lot of pixels are changed. Based on my tests, this really improves performance if making animations across e.g. a 2x2 multitrellis.

Of course, I've left the default behavior as-is for backwards compatibility.